### PR TITLE
Added Deep Mob Learning: Refabricated mod compatibility

### DIFF
--- a/src/main/resources/data/dml-refabricated/tags/entity_types/slimy_mobs.json
+++ b/src/main/resources/data/dml-refabricated/tags/entity_types/slimy_mobs.json
@@ -1,0 +1,27 @@
+{
+  "replace": false,
+  "values": [
+    "terrarianslimes:green_slime",
+    "terrarianslimes:blue_slime",
+    "terrarianslimes:red_slime",
+    "terrarianslimes:purple_slime",
+    "terrarianslimes:yellow_slime",
+    "terrarianslimes:black_slime",
+    "terrarianslimes:ice_slime",
+    "terrarianslimes:sand_slime",
+    "terrarianslimes:jungle_slime",
+    "terrarianslimes:spiked_ice_slime",
+    "terrarianslimes:spiked_jungle_slime",
+    "terrarianslimes:mother_slime",
+    "terrarianslimes:baby_slime",
+    "terrarianslimes:lava_slime",
+    "terrarianslimes:pinky",
+    "terrarianslimes:spiked_slime",
+    "terrarianslimes:umbrella_slime",
+    "terrarianslimes:corrupt_slime",
+    "terrarianslimes:slimeling",
+    "terrarianslimes:crimslime",
+    "terrarianslimes:illuminant_slime",
+    "terrarianslimes:rainbow_slime"
+  ]
+}


### PR DESCRIPTION
Adds compatibility with the 'Deep Mob Learning: Refabricated' mod by allowing Terrarian Slimes' loot (except King Slime) to be generated with Slimy Pristine Matter.

![image](https://user-images.githubusercontent.com/33578169/154494527-9640f459-ff7c-4b25-8d38-5b2ad1f97c93.png)
